### PR TITLE
Manejar errores al cargar el modelo de ración

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,15 +50,16 @@ app.post("/login", usuarios.Login)
 
 app.post("/eventos", eventos.Crear);                        
 app.get("/mascotas/:id/eventos", eventos.Listar);           
-app.get("/mascotas/:id/ticks", eventos.TicksDelDia);      
+app.get("/mascotas/:id/ticks", eventos.TicksDelDia);
 
-const M = JSON.parse(fs.readFileSync("./ml/racion_model_es.json","utf8"))
+let M;
 
 function clamp(v, lo, hi){ return Math.max(lo, Math.min(hi, v)) }
 function clasificarTamanio(p){ if(p<10) return "mini"; if(p<25) return "mediana"; return "grande" }
 
 app.post("/api/v1/racion_ml", (req,res)=>{
   try{
+    if (!M) return res.status(503).json({ ok:false, error:"model_not_loaded" })
     const p = req.body || {}
     const peso_kg   = clamp(Number(p.peso_kg||0), 0.5, 90)
     const edad_meses= clamp(Number(p.edad_meses||0), 0, 240)
@@ -102,4 +103,13 @@ app.post("/api/v1/racion_ml", (req,res)=>{
 
 // Iniciar servidor
 let puerto = 3000;
-app.listen(puerto, () => console.log(`Servidor corriendo en puerto ${puerto}`));
+app.listen(puerto, async () => {
+  try {
+    const data = await fs.promises.readFile("./ml/racion_model_es.json", "utf8")
+    M = JSON.parse(data)
+    console.log(`Servidor corriendo en puerto ${puerto}`)
+  } catch (err) {
+    console.error("No se pudo cargar el modelo de ración:", err)
+    process.exit(1)
+  }
+});

--- a/ml/racion_es.js
+++ b/ml/racion_es.js
@@ -1,7 +1,13 @@
 import fs from "fs"
 
 const MODEL_PATH = process.env.RACION_MODEL_PATH || "racion_model_es.json"
-const M = JSON.parse(fs.readFileSync(MODEL_PATH,"utf8"))
+let M
+try {
+  M = JSON.parse(fs.readFileSync(MODEL_PATH, "utf8"))
+} catch (err) {
+  console.error(`Error al cargar el modelo de ración (${MODEL_PATH}):`, err)
+  throw err
+}
 
 export function predecirRacionES(features){
   let y = M.intercept


### PR DESCRIPTION
## Summary
- Carga del modelo de ración de forma asíncrona al iniciar el servidor
- Manejo de errores al leer el modelo con mensajes claros

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c1aba41170832bb1c066ba1dbe37dd