### PR TITLE
Add JWT-based auth middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+JWT_SECRET=your_secret_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/controllers/usuarios.js
+++ b/controllers/usuarios.js
@@ -1,5 +1,6 @@
-import { query } from "../db.js"
-import bcrypt from "bcryptjs"
+import { query } from "../db.js";
+import bcrypt from "bcryptjs";
+import jwt from "jsonwebtoken";
 
 
 export const Listar = async (req, res) => {
@@ -48,5 +49,6 @@ export const Login = async (req, res) => {
   let u = r.rows[0]
   let ok = await bcrypt.compare(password, u.password)
   if (!ok) return res.status(401).json({ error: "Credenciales" })
-  res.json({ id: u.id, nombre: u.nombre, email: u.email, rol: u.rol })
+  let token = jwt.sign({ id: u.id, rol: u.rol }, process.env.JWT_SECRET, { expiresIn: '1h' })
+  res.json({ token, id: u.id, nombre: u.nombre, email: u.email, rol: u.rol })
 }

--- a/index.js
+++ b/index.js
@@ -10,28 +10,34 @@ import * as horarios from "./controllers/horarios.js";
 import * as usuarios from "./controllers/usuarios.js";
 import * as planes from "./controllers/planes.js";
 import * as eventos from "./controllers/eventos.js";
+import { verifyToken } from "./middlewares/verifyToken.js";
 
 
 let app = express();
 app.use(cors());
 app.use(express.json());
 
-// Ruta de prueba
+// Rutas públicas
 app.get("/", (req, res) => res.json({ ok: true, api: "PetCare" }));
+app.post("/login", usuarios.Login);
+app.post("/usuarios", usuarios.Crear);
+
+// Middleware de verificación
+app.use(verifyToken);
 
 // Rutas Mascotas
-app.get("/mascotas", mascotas.Listar)
-app.get("/mascotas/:id", mascotas.Obtener)
-app.post("/mascotas", mascotas.Crear)
-app.put("/mascotas/:id", mascotas.Actualizar)
-app.delete("/mascotas/:id", mascotas.Eliminar)
-app.get("/mascotas/:id/horarios", mascotas.HorariosDeMascota)
+app.get("/mascotas", mascotas.Listar);
+app.get("/mascotas/:id", mascotas.Obtener);
+app.post("/mascotas", mascotas.Crear);
+app.put("/mascotas/:id", mascotas.Actualizar);
+app.delete("/mascotas/:id", mascotas.Eliminar);
+app.get("/mascotas/:id/horarios", mascotas.HorariosDeMascota);
 
 // Rutas Planes
 app.post("/db/plan", planes.GuardarPlanDB);
-app.get("/db/plan/:id", planes.ObtenerPlanDB);             
-app.get("/db/mismascotas/:id", planes.MisMascotasDB);  
-app.get("/db/planes", planes.Listar);  
+app.get("/db/plan/:id", planes.ObtenerPlanDB);
+app.get("/db/mismascotas/:id", planes.MisMascotasDB);
+app.get("/db/planes", planes.Listar);
 
 // Rutas Planes extra (además de las tuyas)
 app.get("/db/plan/ultimo/:userId", planes.UltimoPlanDeUsuario);
@@ -39,18 +45,15 @@ app.post("/db/plan/:id/activar", planes.Activar);
 app.post("/db/plan/:id/desactivar", planes.Desactivar);
 app.post("/db/plan/:id/sync", planes.RegistrarSync);
 
-
 // Rutas Usuarios
-app.get("/usuarios", usuarios.Listar)
-app.get("/usuarios/:id", usuarios.Obtener)
-app.post("/usuarios", usuarios.Crear)
-app.put("/usuarios/:id", usuarios.Actualizar)
-app.delete("/usuarios/:id", usuarios.Eliminar)
-app.post("/login", usuarios.Login)
+app.get("/usuarios", usuarios.Listar);
+app.get("/usuarios/:id", usuarios.Obtener);
+app.put("/usuarios/:id", usuarios.Actualizar);
+app.delete("/usuarios/:id", usuarios.Eliminar);
 
-app.post("/eventos", eventos.Crear);                        
-app.get("/mascotas/:id/eventos", eventos.Listar);           
-app.get("/mascotas/:id/ticks", eventos.TicksDelDia);      
+app.post("/eventos", eventos.Crear);
+app.get("/mascotas/:id/eventos", eventos.Listar);
+app.get("/mascotas/:id/ticks", eventos.TicksDelDia);
 
 const M = JSON.parse(fs.readFileSync("./ml/racion_model_es.json","utf8"))
 

--- a/middlewares/verifyToken.js
+++ b/middlewares/verifyToken.js
@@ -1,0 +1,14 @@
+import jwt from "jsonwebtoken";
+
+export const verifyToken = (req, res, next) => {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+  if (!token) return res.status(401).json({ error: "Token requerido" });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: "Token inválido" });
+  }
+};


### PR DESCRIPTION
## Summary
- sign JWT tokens on user login and return token with user info
- guard private endpoints with verifyToken middleware
- document JWT_SECRET environment variable and ignore local .env

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab72d8d8832badf2e62d7175f198