### PR TITLE
feat: add zod validation

### DIFF
--- a/controllers/eventos.js
+++ b/controllers/eventos.js
@@ -1,5 +1,21 @@
 // controllers/eventos.js
 import { query } from "../db.js";
+import { z } from "zod";
+
+const hhmm = z.string().regex(/^\d{2}:\d{2}$/);
+
+const EventoSchema = z.object({
+  mascota_id: z.number(),
+  plan_id: z.number().nullable().optional(),
+  tipo: z.enum(['servo', 'sensor']),
+  accion: z.enum(['comida', 'agua']),
+  estado: z.enum(['ok', 'fail']),
+  gramos: z.number().nullable().optional(),
+  fuente: z.enum(['plan', 'manual', 'api']).nullable().optional(),
+  detalle: z.string().nullable().optional(),
+  esp_id: z.string().nullable().optional(),
+  slot_hhmm: hhmm.nullable().optional()
+});
 
 /**
  * POST /eventos
@@ -16,19 +32,15 @@ export async function Crear(req, res) {
     const {
       mascota_id,
       plan_id = null,
-      tipo,          // 'servo' | 'sensor'
-      accion,        // 'comida' | 'agua'
-      estado,        // 'ok' | 'fail'
+      tipo,
+      accion,
+      estado,
       gramos = null,
-      fuente = null, // 'plan' | 'manual' | 'api'
+      fuente = null,
       detalle = null,
       esp_id = null,
       slot_hhmm = null
-    } = req.body;
-
-    if (!mascota_id || !tipo || !accion || !estado) {
-      return res.status(400).json({ ok: false, message: "Faltan campos obligatorios" });
-    }
+    } = EventoSchema.parse(req.body);
 
     const sql = `
       INSERT INTO feed_eventos
@@ -41,6 +53,9 @@ export async function Crear(req, res) {
 
     res.json({ ok: true, evento: rows[0] });
   } catch (e) {
+    if (e instanceof z.ZodError) {
+      return res.status(400).json({ ok: false, error: e.errors });
+    }
     // Si hay conflicto por uq_tick_por_slot_dia, devolvemos 200 igualmente con un hint
     if (e.code === '23505') {
       return res.json({ ok: true, duplicated: true, message: "Ya existe un tick OK para ese slot hoy." });

--- a/controllers/horarios.js
+++ b/controllers/horarios.js
@@ -1,4 +1,16 @@
 import { query } from "../db.js";
+import { z } from "zod";
+
+const HorarioSchema = z.object({
+    mascota_id: z.number(),
+    hora_local: z.string().regex(/^\d{2}:\d{2}$/),
+    gramos: z.number(),
+    dias: z.string()
+});
+
+const HorarioUpdateSchema = HorarioSchema.partial().extend({
+    activo: z.boolean().optional()
+});
 
 export const Listar = async (req, res) => {
     let r = await query("SELECT * FROM horarios ORDER BY hora_local ASC");
@@ -6,22 +18,32 @@ export const Listar = async (req, res) => {
 };
 
 export const Crear = async (req, res) => {
-    let { mascota_id, hora_local, gramos, dias } = req.body;
-    let r = await query(
-        "INSERT INTO horarios(mascota_id,hora_local,gramos,dias) VALUES($1,$2,$3,$4) RETURNING *",
-        [mascota_id, hora_local, gramos, dias]
-    );
-    res.status(201).json(r.rows[0]);
+    try {
+        let { mascota_id, hora_local, gramos, dias } = HorarioSchema.parse(req.body);
+        let r = await query(
+            "INSERT INTO horarios(mascota_id,hora_local,gramos,dias) VALUES($1,$2,$3,$4) RETURNING *",
+            [mascota_id, hora_local, gramos, dias]
+        );
+        res.status(201).json(r.rows[0]);
+    } catch (e) {
+        if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+        throw e;
+    }
 };
 
 export const Actualizar = async (req, res) => {
-    let { hora_local, gramos, dias, activo } = req.body;
-    let r = await query(
-        "UPDATE horarios SET hora_local=$2,gramos=$3,dias=$4,activo=COALESCE($5,activo) WHERE id=$1 RETURNING *",
-        [req.params.id, hora_local, gramos, dias, activo]
-    );
-    if (!r.rowCount) return res.status(404).json({ error: "No encontrado" });
-    res.json(r.rows[0]);
+    try {
+        let { hora_local, gramos, dias, activo } = HorarioUpdateSchema.parse(req.body);
+        let r = await query(
+            "UPDATE horarios SET hora_local=$2,gramos=$3,dias=$4,activo=COALESCE($5,activo) WHERE id=$1 RETURNING *",
+            [req.params.id, hora_local, gramos, dias, activo]
+        );
+        if (!r.rowCount) return res.status(404).json({ error: "No encontrado" });
+        res.json(r.rows[0]);
+    } catch (e) {
+        if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+        throw e;
+    }
 };
 
 export const Eliminar = async (req, res) => {

--- a/controllers/mascotas.js
+++ b/controllers/mascotas.js
@@ -1,4 +1,17 @@
 import { query } from "../db.js";
+import { z } from "zod";
+
+const MascotaSchema = z.object({
+  nombre: z.string(),
+  sexo: z.string(),
+  raza: z.string().optional(),
+  peso_kg: z.number(),
+  fecha_nacimiento: z.string().optional(),
+  usuario_id: z.number(),
+  kcal_100g: z.number().optional()
+});
+
+const MascotaUpdateSchema = MascotaSchema.partial();
 
 export const Listar = async (req, res) => {
   let r = await query("SELECT * FROM mascotas ORDER BY creado_en DESC");
@@ -12,29 +25,39 @@ export const Obtener = async (req, res) => {
 };
 
 export const Crear = async (req, res) => {
-  let { nombre, sexo, raza, peso_kg, fecha_nacimiento, usuario_id, kcal_100g } = req.body;
-  let r = await query(
-    "INSERT INTO mascotas(nombre, sexo, raza, peso_kg, fecha_nacimiento, usuario_id, kcal_100g) VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *",
-    [nombre, sexo, raza, peso_kg, fecha_nacimiento || null, usuario_id, kcal_100g || null]
-  );
-  res.status(201).json(r.rows[0]);
+  try {
+    let { nombre, sexo, raza, peso_kg, fecha_nacimiento, usuario_id, kcal_100g } = MascotaSchema.parse(req.body);
+    let r = await query(
+      "INSERT INTO mascotas(nombre, sexo, raza, peso_kg, fecha_nacimiento, usuario_id, kcal_100g) VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *",
+      [nombre, sexo, raza, peso_kg, fecha_nacimiento || null, usuario_id, kcal_100g || null]
+    );
+    res.status(201).json(r.rows[0]);
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    throw e;
+  }
 };
 
 export const Actualizar = async (req, res) => {
-  let { nombre, sexo, raza, peso_kg, fecha_nacimiento, kcal_100g } = req.body;
-  let r = await query(
-    `UPDATE mascotas 
-     SET nombre = COALESCE($2,nombre),
-         sexo = COALESCE($3,sexo),
-         raza = COALESCE($4,raza),
-         peso_kg = COALESCE($5,peso_kg),
-         fecha_nacimiento = COALESCE($6,fecha_nacimiento),
-         kcal_100g = COALESCE($7,kcal_100g)
-     WHERE id=$1 RETURNING *`,
-    [req.params.id, nombre, sexo, raza, peso_kg, fecha_nacimiento || null, kcal_100g || null]
-  );
-  if (!r.rowCount) return res.status(404).json({ error: "No encontrada" });
-  res.json(r.rows[0]);
+  try {
+    let { nombre, sexo, raza, peso_kg, fecha_nacimiento, kcal_100g } = MascotaUpdateSchema.parse(req.body);
+    let r = await query(
+      `UPDATE mascotas
+       SET nombre = COALESCE($2,nombre),
+           sexo = COALESCE($3,sexo),
+           raza = COALESCE($4,raza),
+           peso_kg = COALESCE($5,peso_kg),
+           fecha_nacimiento = COALESCE($6,fecha_nacimiento),
+           kcal_100g = COALESCE($7,kcal_100g)
+       WHERE id=$1 RETURNING *`,
+      [req.params.id, nombre, sexo, raza, peso_kg, fecha_nacimiento || null, kcal_100g || null]
+    );
+    if (!r.rowCount) return res.status(404).json({ error: "No encontrada" });
+    res.json(r.rows[0]);
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors });
+    throw e;
+  }
 };
 
 export const Eliminar = async (req, res) => {

--- a/controllers/planes.js
+++ b/controllers/planes.js
@@ -1,26 +1,40 @@
 // controllers/planes.js
 import { query } from "../db.js";
+import { z } from "zod";
 
-/**
- * Normaliza strings "HH:MM" a tipo TIME[] (Postgres) cuando el modo es repeat_week
- */
-function toTimeArray(arr) {
-  if (!Array.isArray(arr)) return null;
-  // Validar HH:MM
-  const ok = arr.every(s => typeof s === "string" && /^\d{2}:\d{2}$/.test(s));
-  return ok ? arr : null;
-}
+const time = z.string().regex(/^\d{2}:\d{2}$/);
 
-/**
- * Valida que weekplan sea un array de 7 arrays con "HH:MM"
- */
-function validateWeekplan(wp) {
-  if (!Array.isArray(wp) || wp.length !== 7) return false;
-  return wp.every(dayArr =>
-    Array.isArray(dayArr) &&
-    dayArr.every(s => typeof s === "string" && /^\d{2}:\d{2}$/.test(s))
-  );
-}
+const PlanSchema = z.object({
+  mode: z.enum(['repeat_week', 'per_day']),
+  secondsOpen: z.number().positive(),
+  dayplan: z.array(time).optional(),
+  weekplan: z.array(z.array(time)).optional()
+}).superRefine((data, ctx) => {
+  if (data.mode === 'repeat_week') {
+    if (!data.dayplan || data.dayplan.length === 0) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'dayplan requerido para repeat_week', path: ['dayplan'] });
+    }
+  } else if (data.mode === 'per_day') {
+    if (!data.weekplan || data.weekplan.length !== 7) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'weekplan inválido para per_day', path: ['weekplan'] });
+    }
+  }
+});
+
+const GuardarPlanSchema = z.object({
+  userId: z.number(),
+  plan: PlanSchema,
+  gramsPerMeal: z.number().positive(),
+  hopper: z.number().nullable().optional(),
+  esp: z.object({ ip: z.string(), port: z.string() }).optional()
+});
+
+const RegistrarSyncSchema = z.object({
+  userId: z.number(),
+  ok: z.boolean(),
+  message: z.string().optional(),
+  esp: z.object({ ip: z.string(), port: z.string() }).optional()
+});
 
 /**
  * POST /db/plan
@@ -35,35 +49,11 @@ function validateWeekplan(wp) {
  */
 export const GuardarPlanDB = async (req, res) => {
   try {
-    const { userId, plan, gramsPerMeal, hopper, esp } = req.body || {};
-    if (!userId || !plan || typeof plan.mode !== "string" || !plan.secondsOpen) {
-      return res.status(400).json({ error: "Faltan campos obligatorios (userId, plan.mode, plan.secondsOpen)" });
-    }
-    if (!Number.isFinite(gramsPerMeal) || gramsPerMeal <= 0) {
-      return res.status(400).json({ error: "gramsPerMeal inválido" });
-    }
-    const secondsOpen = Number(plan.secondsOpen);
-    if (!Number.isFinite(secondsOpen) || secondsOpen <= 0) {
-      return res.status(400).json({ error: "secondsOpen inválido" });
-    }
-
-    let mode = plan.mode;
-    let dayplan = null;
-    let weekplan = null;
-
-    if (mode === "repeat_week") {
-      dayplan = toTimeArray(plan.dayplan);
-      if (!dayplan || dayplan.length === 0) {
-        return res.status(400).json({ error: "dayplan inválido o vacío para repeat_week" });
-      }
-    } else if (mode === "per_day") {
-      if (!validateWeekplan(plan.weekplan)) {
-        return res.status(400).json({ error: "weekplan inválido (debe ser 7 arrays de HH:MM)" });
-      }
-      weekplan = plan.weekplan;
-    } else {
-      return res.status(400).json({ error: "mode debe ser 'repeat_week' o 'per_day'" });
-    }
+    const { userId, plan, gramsPerMeal, hopper, esp } = GuardarPlanSchema.parse(req.body);
+    const mode = plan.mode;
+    const secondsOpen = plan.secondsOpen;
+    const dayplan = mode === 'repeat_week' ? plan.dayplan : null;
+    const weekplan = mode === 'per_day' ? plan.weekplan : null;
 
     const r = await query(
       `INSERT INTO planes (user_id, mode, seconds_open, dayplan, weekplan, grams_per_meal, hopper_g, esp)
@@ -73,8 +63,8 @@ export const GuardarPlanDB = async (req, res) => {
         userId,
         mode,
         secondsOpen,
-        dayplan,           // ::time[]
-        weekplan ? JSON.stringify(weekplan) : null, // ::jsonb
+        dayplan,
+        weekplan ? JSON.stringify(weekplan) : null,
         gramsPerMeal,
         Number.isFinite(hopper) ? hopper : null,
         esp ? JSON.stringify(esp) : null
@@ -83,6 +73,9 @@ export const GuardarPlanDB = async (req, res) => {
 
     res.status(201).json(r.rows[0]);
   } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ error: err.errors });
+    }
     console.error("GuardarPlanDB error:", err);
     res.status(500).json({ error: "Error al guardar el plan" });
   }
@@ -207,9 +200,9 @@ export const MisMascotasDB = async (_req, res) => {
 export const RegistrarSync = async (req, res) => {
   try {
     const planId = Number(req.params.id);
-    const { userId, ok, message, esp } = req.body || {};
-    if (!Number.isFinite(planId) || !userId || typeof ok !== "boolean") {
-      return res.status(400).json({ error: "Faltan datos (planId, userId, ok)" });
+    const { userId, ok, message, esp } = RegistrarSyncSchema.parse(req.body);
+    if (!Number.isFinite(planId)) {
+      return res.status(400).json({ error: "planId inválido" });
     }
     const r = await query(
       `INSERT INTO plan_syncs (plan_id, user_id, ok, message, esp)
@@ -219,6 +212,9 @@ export const RegistrarSync = async (req, res) => {
     );
     res.status(201).json({ ok: true, id: r.rows[0].id, created_at: r.rows[0].created_at });
   } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ error: err.errors });
+    }
     console.error("RegistrarSync error:", err);
     res.status(500).json({ error: "Error al registrar sincronización" });
   }

--- a/controllers/usuarios.js
+++ b/controllers/usuarios.js
@@ -1,5 +1,20 @@
 import { query } from "../db.js"
 import bcrypt from "bcryptjs"
+import { z } from "zod"
+
+const UsuarioSchema = z.object({
+  nombre: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+  rol: z.string().optional()
+})
+
+const UsuarioUpdateSchema = UsuarioSchema.partial()
+
+const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string()
+})
 
 
 export const Listar = async (req, res) => {
@@ -14,25 +29,35 @@ export const Obtener = async (req, res) => {
 }
 
 export const Crear = async (req, res) => {
-  let { nombre, email, password, rol } = req.body
-  let hash = await bcrypt.hash(password, 10)
-  let r = await query(
-    "insert into usuarios(nombre,email,password,rol) values($1,$2,$3,coalesce($4,'usuario')) returning id,nombre,email,fecha_registro,rol",
-    [nombre, email, hash, rol]
-  )
-  res.status(201).json(r.rows[0])
+  try {
+    let { nombre, email, password, rol } = UsuarioSchema.parse(req.body)
+    let hash = await bcrypt.hash(password, 10)
+    let r = await query(
+      "insert into usuarios(nombre,email,password,rol) values($1,$2,$3,coalesce($4,'usuario')) returning id,nombre,email,fecha_registro,rol",
+      [nombre, email, hash, rol]
+    )
+    res.status(201).json(r.rows[0])
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors })
+    throw e
+  }
 }
 
 export const Actualizar = async (req, res) => {
-  let { nombre, email, password, rol } = req.body
-  let pass = null
-  if (password && password.length > 0) pass = await bcrypt.hash(password, 10)
-  let r = await query(
-    "update usuarios set nombre=coalesce($2,nombre), email=coalesce($3,email), password=coalesce($4,password), rol=coalesce($5,rol) where id=$1 returning id,nombre,email,fecha_registro,rol",
-    [req.params.id, nombre, email, pass, rol]
-  )
-  if (!r.rowCount) return res.status(404).json({ error: "No encontrado" })
-  res.json(r.rows[0])
+  try {
+    let { nombre, email, password, rol } = UsuarioUpdateSchema.parse(req.body)
+    let pass = null
+    if (password && password.length > 0) pass = await bcrypt.hash(password, 10)
+    let r = await query(
+      "update usuarios set nombre=coalesce($2,nombre), email=coalesce($3,email), password=coalesce($4,password), rol=coalesce($5,rol) where id=$1 returning id,nombre,email,fecha_registro,rol",
+      [req.params.id, nombre, email, pass, rol]
+    )
+    if (!r.rowCount) return res.status(404).json({ error: "No encontrado" })
+    res.json(r.rows[0])
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors })
+    throw e
+  }
 }
 
 export const Eliminar = async (req, res) => {
@@ -42,11 +67,16 @@ export const Eliminar = async (req, res) => {
 }
 
 export const Login = async (req, res) => {
-  let { email, password } = req.body
-  let r = await query("select * from usuarios where email=$1", [email])
-  if (!r.rowCount) return res.status(401).json({ error: "Credenciales" })
-  let u = r.rows[0]
-  let ok = await bcrypt.compare(password, u.password)
-  if (!ok) return res.status(401).json({ error: "Credenciales" })
-  res.json({ id: u.id, nombre: u.nombre, email: u.email, rol: u.rol })
+  try {
+    let { email, password } = LoginSchema.parse(req.body)
+    let r = await query("select * from usuarios where email=$1", [email])
+    if (!r.rowCount) return res.status(401).json({ error: "Credenciales" })
+    let u = r.rows[0]
+    let ok = await bcrypt.compare(password, u.password)
+    if (!ok) return res.status(401).json({ error: "Credenciales" })
+    res.json({ id: u.id, nombre: u.nombre, email: u.email, rol: u.rol })
+  } catch (e) {
+    if (e instanceof z.ZodError) return res.status(400).json({ error: e.errors })
+    throw e
+  }
 }


### PR DESCRIPTION
## Summary
- add zod schemas for usuarios, mascotas, horarios, eventos and planes
- validate request bodies with schema.parse before DB queries
- return 400 on validation errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab71b1e0832bbc017eba1f871d33