### PR TITLE
Configure server port and CORS via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+ALLOWED_ORIGINS=http://localhost:3000

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ import * as eventos from "./controllers/eventos.js";
 
 
 let app = express();
-app.use(cors());
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || "";
+app.use(cors({ origin: ALLOWED_ORIGINS.split(',') }));
 app.use(express.json());
 
 // Ruta de prueba
@@ -101,5 +102,5 @@ app.post("/api/v1/racion_ml", (req,res)=>{
 
 
 // Iniciar servidor
-let puerto = 3000;
+const puerto = process.env.PORT || 3000;
 app.listen(puerto, () => console.log(`Servidor corriendo en puerto ${puerto}`));


### PR DESCRIPTION
## Summary
- load allowed origins from `ALLOWED_ORIGINS` environment variable for CORS
- read port from `PORT` environment variable and add example `.env`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab5a7ef8832bb3ce71d6552733ec