### PR TITLE
Configure database via environment variables with SSL certificates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DB_HOST=your_database_host
+DB_USER=your_database_user
+DB_PASS=your_database_password
+DB_NAME=your_database_name
+DB_PORT=5432
+DB_SSL_CA=path/to/server-ca.pem
+DB_SSL_KEY=path/to/client-key.pem
+DB_SSL_CERT=path/to/client-cert.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/db.js
+++ b/db.js
@@ -1,14 +1,21 @@
 import pkg from "pg";
+import dotenv from "dotenv";
+import fs from "fs";
+
+dotenv.config();
+
 const { Pool } = pkg;
 
 export const pool = new Pool({
-    host: "ep-spring-night-acu7toll-pooler.sa-east-1.aws.neon.tech",
-    user: "neondb_owner",
-    password: "npg_gBKFm9ETa8CQ",
-    database: "neondb",
-    port: 5432,
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME,
+    port: Number(process.env.DB_PORT),
     ssl: {
-        rejectUnauthorized: false,
+        ca: fs.readFileSync(process.env.DB_SSL_CA),
+        key: fs.readFileSync(process.env.DB_SSL_KEY),
+        cert: fs.readFileSync(process.env.DB_SSL_CERT),
     },
 });
 


### PR DESCRIPTION
## Summary
- load database configuration from environment variables using dotenv
- secure PostgreSQL connection using certificate-based SSL
- document required settings in `.env.example` and ignore real `.env`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab501648832bb5c711d26c696b07