### PR TITLE
feat: add pet stats and weight tracking

### DIFF
--- a/controllers/mascotas.js
+++ b/controllers/mascotas.js
@@ -59,3 +59,71 @@ export const ListarPorUsuario = async (req, res) => {
   );
   res.json(r.rows);
 };
+
+export const RegistrarPeso = async (req, res) => {
+  const id = Number(req.params.id);
+  const { peso_kg } = req.body || {};
+  if (!Number.isFinite(peso_kg))
+    return res.status(400).json({ error: "peso_kg requerido" });
+
+  const r = await query(
+    "INSERT INTO mascota_pesos (mascota_id, peso_kg) VALUES ($1,$2) RETURNING id, mascota_id, peso_kg, registrado_en",
+    [id, peso_kg]
+  );
+  res.status(201).json(r.rows[0]);
+};
+
+export const Stats = async (req, res) => {
+  const id = Number(req.params.id);
+  const days = Number(req.query.days || 7);
+  try {
+    const pesosR = await query(
+      "SELECT registrado_en::date AS fecha, peso_kg FROM mascota_pesos WHERE mascota_id=$1 ORDER BY registrado_en",
+      [id]
+    );
+
+    const comidasR = await query(
+      `WITH dias AS (
+         SELECT generate_series(current_date - $2::int + 1, current_date, '1 day')::date AS dia
+       )
+       SELECT d.dia,
+         COALESCE(cp.planificadas,0) AS planificadas,
+         COALESCE(ev.realizadas,0) AS realizadas,
+         COALESCE(ag.cantidad,0)   AS agua
+       FROM dias d
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) planificadas
+         FROM comidas_programadas
+         WHERE mascota_id=$1 AND dia_semana = extract(isodow from d.dia)
+       ) cp ON true
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) realizadas
+         FROM feed_eventos
+         WHERE mascota_id=$1 AND accion='comida' AND estado='ok' AND created_at::date = d.dia
+       ) ev ON true
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*) cantidad
+         FROM feed_eventos
+         WHERE mascota_id=$1 AND accion='agua' AND estado='ok' AND created_at::date = d.dia
+       ) ag ON true
+       ORDER BY d.dia`,
+      [id, days]
+    );
+
+    res.json({
+      pesos: pesosR.rows,
+      comidas: comidasR.rows.map(r => ({
+        fecha: r.dia,
+        planificadas: r.planificadas,
+        realizadas: r.realizadas
+      })),
+      agua: comidasR.rows.map(r => ({
+        fecha: r.dia,
+        eventos: r.agua
+      }))
+    });
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "Error al obtener estadísticas" });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ app.post("/mascotas", mascotas.Crear)
 app.put("/mascotas/:id", mascotas.Actualizar)
 app.delete("/mascotas/:id", mascotas.Eliminar)
 app.get("/mascotas/:id/horarios", mascotas.HorariosDeMascota)
+app.post("/mascotas/:id/pesos", mascotas.RegistrarPeso)
+app.get("/mascotas/:id/stats", mascotas.Stats)
 
 // Rutas Planes
 app.post("/db/plan", planes.GuardarPlanDB);

--- a/petcare.sql
+++ b/petcare.sql
@@ -1,6 +1,7 @@
 BEGIN;
 
 -- Eliminar tablas si ya existen
+DROP TABLE IF EXISTS mascota_pesos CASCADE;
 DROP TABLE IF EXISTS comidas_programadas CASCADE;
 DROP TABLE IF EXISTS dispensador_config CASCADE;
 DROP TABLE IF EXISTS mascotas CASCADE;
@@ -27,6 +28,16 @@ CREATE TABLE mascotas (
   creado_en TIMESTAMPTZ DEFAULT now(),
   usuario_id INTEGER REFERENCES usuarios(id) ON DELETE CASCADE
 );
+
+-- Tabla: registros de peso
+CREATE TABLE mascota_pesos (
+  id SERIAL PRIMARY KEY,
+  mascota_id INTEGER NOT NULL REFERENCES mascotas(id) ON DELETE CASCADE,
+  peso_kg NUMERIC(5,2) NOT NULL,
+  registrado_en TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pesos_mascota ON mascota_pesos (mascota_id);
 
 -- Tabla: configuracion de dispensador
 CREATE TABLE dispensador_config (

--- a/public/estadisticas.html
+++ b/public/estadisticas.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Estadísticas de Mascota</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <main class="phone">
+    <header>
+      <a href="principal.html">&larr; Volver</a>
+    </header>
+
+    <section>
+      <h2>Peso</h2>
+      <canvas id="pesoChart"></canvas>
+    </section>
+
+    <section>
+      <h2>Comidas</h2>
+      <canvas id="comidaChart"></canvas>
+    </section>
+
+    <section>
+      <h2>Agua</h2>
+      <canvas id="aguaChart"></canvas>
+    </section>
+  </main>
+  <script src="estadisticas.js"></script>
+</body>
+</html>

--- a/public/estadisticas.js
+++ b/public/estadisticas.js
@@ -1,0 +1,76 @@
+const DBURL = "http://localhost:3000";
+
+function getMascotaId() {
+  const params = new URLSearchParams(location.search);
+  return Number(params.get("id"));
+}
+
+async function cargarStats(id) {
+  const r = await fetch(`${DBURL}/mascotas/${id}/stats`);
+  if (!r.ok) throw new Error("No se pudieron obtener las estadísticas");
+  return r.json();
+}
+
+function renderCharts(data) {
+  const pesoLabels = data.pesos.map(p => p.fecha);
+  const pesoData = data.pesos.map(p => p.peso_kg);
+  new Chart(document.getElementById("pesoChart"), {
+    type: "line",
+    data: {
+      labels: pesoLabels,
+      datasets: [{
+        label: "Peso (kg)",
+        data: pesoData,
+        borderColor: "#3b82f6",
+        fill: false
+      }]
+    }
+  });
+
+  const comidaLabels = data.comidas.map(c => c.fecha);
+  new Chart(document.getElementById("comidaChart"), {
+    type: "bar",
+    data: {
+      labels: comidaLabels,
+      datasets: [
+        {
+          label: "Planificadas",
+          data: data.comidas.map(c => c.planificadas),
+          backgroundColor: "rgba(255,99,132,0.5)"
+        },
+        {
+          label: "Realizadas",
+          data: data.comidas.map(c => c.realizadas),
+          backgroundColor: "rgba(75,192,192,0.5)"
+        }
+      ]
+    }
+  });
+
+  const aguaLabels = data.agua.map(a => a.fecha);
+  new Chart(document.getElementById("aguaChart"), {
+    type: "bar",
+    data: {
+      labels: aguaLabels,
+      datasets: [{
+        label: "Eventos de agua",
+        data: data.agua.map(a => a.eventos),
+        backgroundColor: "rgba(54,162,235,0.5)"
+      }]
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const id = getMascotaId();
+  if (!id) {
+    alert("Mascota inválida");
+    return;
+  }
+  try {
+    const stats = await cargarStats(id);
+    renderCharts(stats);
+  } catch (e) {
+    alert(e.message || "Error al cargar estadísticas");
+  }
+});

--- a/public/perfil.js
+++ b/public/perfil.js
@@ -176,6 +176,14 @@ function wireEditorMascota(userId) {
         const d = await r.json();
         if (!r.ok) throw new Error(d.error || "Error");
 
+        if (body.peso_kg != null) {
+          await fetch(`${DBURL}/mascotas/${id}/pesos`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ peso_kg: body.peso_kg })
+          });
+        }
+
         alert("Mascota actualizada");
         await cargarMascotas(userId);
       } catch (e) {

--- a/public/principal.html
+++ b/public/principal.html
@@ -20,10 +20,14 @@
            style="width:200px; height:200px;border-radius:8px;" 
            alt="Cámara en vivo">
     </section>
-    
+
+    <section id="mascotas">
+      <ul id="lista-mascotas"></ul>
+    </section>
+
     <script>
       function moverServo() {
-        fetch("http://192.168.0.244:8080/servo")   
+        fetch("http://192.168.0.244:8080/servo")
           .then(r => r.text())
           .then(t => console.log(t));
       }
@@ -83,6 +87,7 @@
         }
       });
     </script>
+    <script src="principal.js"></script>
   </main>
 
 </body>

--- a/public/principal.js
+++ b/public/principal.js
@@ -1,0 +1,35 @@
+const DBURL = "http://localhost:3000";
+
+function getUsuario() {
+  try {
+    return JSON.parse(localStorage.getItem("usuario")) || JSON.parse(localStorage.getItem("petcare_user"));
+  } catch {
+    return null;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const u = getUsuario();
+  if (!u || !u.id) return;
+
+  const lista = document.getElementById("lista-mascotas");
+  if (!lista) return;
+
+  try {
+    const r = await fetch(`${DBURL}/mascotas`);
+    const data = await r.json();
+    const mias = data.filter(m => m.usuario_id === u.id);
+    if (mias.length === 0) {
+      lista.innerHTML = "<li>No hay mascotas</li>";
+      return;
+    }
+    lista.innerHTML = mias.map(m => `
+      <li class="item">
+        <span class="name">${m.nombre}</span>
+        <a class="btn" href="estadisticas.html?id=${m.id}">Estadísticas</a>
+      </li>
+    `).join("");
+  } catch (e) {
+    lista.innerHTML = "<li>Error al cargar mascotas</li>";
+  }
+});


### PR DESCRIPTION
## Summary
- add HTML and JS to display pet statistics with Chart.js
- track pet weight history and expose `/mascotas/:id/stats`
- link stats page from principal view and persist weight updates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ad71acd8832bbda7cc2cc844ef5f