### PR TITLE
Evitar múltiples mascotas por usuario

### DIFF
--- a/controllers/mascotas.js
+++ b/controllers/mascotas.js
@@ -13,6 +13,8 @@ export const Obtener = async (req, res) => {
 
 export const Crear = async (req, res) => {
   let { nombre, sexo, raza, peso_kg, fecha_nacimiento, usuario_id, kcal_100g } = req.body;
+  const existe = await query('SELECT 1 FROM mascotas WHERE usuario_id=$1', [usuario_id]);
+  if (existe.rowCount) return res.status(409).json({ error: "Mascota ya registrada" });
   let r = await query(
     "INSERT INTO mascotas(nombre, sexo, raza, peso_kg, fecha_nacimiento, usuario_id, kcal_100g) VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *",
     [nombre, sexo, raza, peso_kg, fecha_nacimiento || null, usuario_id, kcal_100g || null]

--- a/petcare.sql
+++ b/petcare.sql
@@ -27,6 +27,7 @@ CREATE TABLE mascotas (
   creado_en TIMESTAMPTZ DEFAULT now(),
   usuario_id INTEGER REFERENCES usuarios(id) ON DELETE CASCADE
 );
+ALTER TABLE mascotas ADD CONSTRAINT unique_usuario UNIQUE (usuario_id);
 
 -- Tabla: configuracion de dispensador
 CREATE TABLE dispensador_config (

--- a/public/mascota.js
+++ b/public/mascota.js
@@ -33,7 +33,7 @@ function requireVal(cond, msg) {
   return true;
 }
 
-(function initUser(){
+(async function initUser(){
   let user = localStorage.getItem("usuario");
   if (!user) { alert("inicia sesion"); location.href = "login.html"; return; }
   try {
@@ -41,6 +41,13 @@ function requireVal(cond, msg) {
     datos.usuario_id = u?.id || null;
   } catch(e) {}
   if (!datos.usuario_id) { alert("no se encontro el usuario"); location.href = "login.html"; return; }
+  try {
+    const r = await fetch(`${API}/mascotas?usuario_id=${datos.usuario_id}`);
+    if (r.ok) {
+      const lista = await r.json();
+      if (Array.isArray(lista) && lista.length) { location.href = "principal.html"; return; }
+    }
+  } catch(e) {}
   showStep(1);
 })();
 

--- a/public/principal.html
+++ b/public/principal.html
@@ -45,11 +45,17 @@
         window.location.href = "plandecomidas.html";
       });
 
-      (function () {
+      (async function () {
         try {
           const u = JSON.parse(localStorage.getItem("usuario"));
           if (!u || !u.id) {
             window.location.replace("index.html");
+            return;
+          }
+          const r = await fetch(`/mascotas?usuario_id=${u.id}`);
+          const lista = await r.json();
+          if (Array.isArray(lista) && lista.length) {
+            localStorage.setItem("mascota", JSON.stringify(lista[0]));
           }
         } catch (_) {
           window.location.replace("index.html");


### PR DESCRIPTION
## Summary
- Add unique constraint on `usuario_id` in `mascotas`
- Validate existing mascota before creation and return 409 conflict
- Front-end redirect if mascota already exists and cache mascota for principal page

## Testing
- `npm test` *(fails: Missing script "test" – no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ae20cdb0832b8c5e3a6e28a904c3