### PR TITLE
feat: add offline queue for feeding events

### DIFF
--- a/public/plandecomidas.html
+++ b/public/plandecomidas.html
@@ -204,10 +204,10 @@
           <button class="btn primary" id="calcIA">Calcular racion</button>
         </div>
       </div>
-      <p class="subtle" id="ia_hint">Hace click en el boton de calcular</p>
+  <p class="subtle" id="ia_hint">Hace click en el boton de calcular</p>
     </div>
   </div>
-
+  <script src="plandecomidas.js"></script>
   <script>
     // ======= urls =======
     const BACKEND_URL = "http://localhost:3000"

--- a/public/plandecomidas.js
+++ b/public/plandecomidas.js
@@ -1,0 +1,73 @@
+// Manejo de cola de eventos offline
+(function(){
+  const BASE_URL = (typeof BACKEND_URL !== 'undefined') ? BACKEND_URL : 'http://localhost:3000';
+  const STORAGE_KEY = 'event_queue';
+
+  function readQueue(){
+    try{
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : [];
+    }catch(_){
+      return [];
+    }
+  }
+
+  function writeQueue(q){
+    try{ localStorage.setItem(STORAGE_KEY, JSON.stringify(q)); }catch(_){ }
+  }
+
+  function showToast(msg){
+    let el = document.getElementById('net-toast');
+    if(!el){
+      el = document.createElement('div');
+      el.id = 'net-toast';
+      Object.assign(el.style, {
+        position:'fixed', left:'50%', bottom:'20px', transform:'translateX(-50%)',
+        background:'#333', color:'#fff', padding:'10px 20px', borderRadius:'6px',
+        opacity:'0', transition:'opacity .3s', zIndex:'1000'
+      });
+      document.body.appendChild(el);
+    }
+    el.textContent = msg;
+    el.style.opacity = '1';
+    setTimeout(()=>{ el.style.opacity = '0'; }, 3000);
+  }
+
+  async function sendToBackend(ev){
+    try{
+      const res = await fetch(`${BASE_URL}/event`, {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify(ev)
+      });
+      return res.ok;
+    }catch(_){
+      return false;
+    }
+  }
+
+  async function flushQueue(){
+    const queue = readQueue();
+    if(queue.length === 0) return;
+    const remaining = [];
+    for(const ev of queue){
+      const ok = await sendToBackend(ev);
+      if(!ok) remaining.push(ev);
+    }
+    writeQueue(remaining);
+  }
+
+  async function registerEvent(mascota_id, horario_id){
+    const ev = { mascota_id, horario_id, timestamp: Date.now() };
+    const ok = await sendToBackend(ev);
+    if(!ok){
+      const q = readQueue();
+      q.push(ev);
+      writeQueue(q);
+      showToast('Se enviará cuando vuelvas a estar online');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', flushQueue);
+  window.registerEvent = registerEvent;
+})();


### PR DESCRIPTION
## Summary
- queue failed feeding events in `localStorage`
- flush pending events on app start
- show toast when event is queued for later sync

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1ae381608832b939ffd450bb404e1